### PR TITLE
Add base64 encoding for share link

### DIFF
--- a/model.js
+++ b/model.js
@@ -15,7 +15,7 @@ addEntry($('#structure .pool').get());
 
 const params = new URLSearchParams(window.location.search);
 if (params.has('q')) {
-  $('#source').val(params.get('q'));
+  $('#source').val(atob(params.get('q')));
   updateSouce();
 }
 
@@ -42,7 +42,7 @@ function showSource() {
 }
 
 function linkSource() {
-  let link = window.location.origin + window.location.pathname + '?q=' + JSON.stringify(table);
+  let link = window.location.origin + window.location.pathname + '?q=' + btoa(JSON.stringify(table));
   $('#copyTextarea').removeClass('d-none').val(link);
   $('#copyTextarea').get()[0].select();
   document.execCommand('copy');


### PR DESCRIPTION
This PR helps make the share link like a regular link 🤣

After merging this, the share link will become something like `http://misode.github.io/loot-table/?q=eyJ0eXBlIjoibWluZWNyYWZ0OmdlbmVyaWMiLCJwb29scyI6W3sicm9sbHMiOjEsImVudHJpZXMiOlt7InR5cGUiOiJtaW5lY3JhZnQ6aXRlbSIsIm5hbWUiOiJtaW5lY3JhZnQ6c3RvbmUifV19XX0=`, instead of showing the JSON directly.

@misode XD