### PR TITLE
Collapsible components

### DIFF
--- a/model.js
+++ b/model.js
@@ -411,3 +411,15 @@ function parseJSONValue(value) {
   }
   return value;
 }
+
+function collapseComponent(el) {
+  let path = getPath(el);
+  let field = path.pop();
+  let node = getNode(path);
+  if (node[field]._collapse) {
+    delete node[field]._collapse
+  } else {
+    node[field]._collapse = true;
+  }
+  invalidated();
+}

--- a/schemas/1.14.json
+++ b/schemas/1.14.json
@@ -404,35 +404,47 @@
           ]
         },
         {
-          "id": "parameters.bonusMultiplier",
-          "type": "float",
-          "translate": "$function.bonusMultiplier",
+          "id": "parameters",
+          "type": "object",
+          "translate": "$function.parameters",
+          "color": "secondary",
+          "card": false,
           "require": [
             {
               "function": "minecraft:apply_bonus",
               "formula": "minecraft:uniform_bonus_count"
             }
+          ],
+          "fields": [
+            {
+              "id": "bonusMultiplier",
+              "type": "float",
+              "translate": "$function.bonusMultiplier"
+            }
           ]
         },
         {
-          "id": "parameters.extra",
-          "type": "int",
-          "translate": "$function.extra",
+          "id": "parameters",
+          "type": "object",
+          "translate": "$function.parameters",
+          "color": "secondary",
+          "card": false,
           "require": [
             {
               "function": "minecraft:apply_bonus",
               "formula": "minecraft:binomial_with_bonus_count"
             }
-          ]
-        },
-        {
-          "id": "parameters.probability",
-          "type": "float",
-          "translate": "$function.probability",
-          "require": [
+          ],
+          "fields": [
             {
-              "function": "minecraft:apply_bonus",
-              "formula": "minecraft:binomial_with_bonus_count"
+              "id": "extra",
+              "type": "int",
+              "translate": "$function.extra"
+            },
+            {
+              "id": "probability",
+              "type": "float",
+              "translate": "$function.probability"
             }
           ]
         },

--- a/view.js
+++ b/view.js
@@ -314,8 +314,16 @@ function generateObject(data, struct, header) {
   if (header) {
     $header.appendTo($el);
     $header.append('<button type="button" class="btn btn-danger mb-2 float-right" onclick="removeComponent(this)" data-i18n="' + struct.id + '_remove"></button>');
+    let icon = 'https://cdnjs.cloudflare.com/ajax/libs/octicons/8.5.0/svg/chevron-down.svg';
+    if (data._collapse) {
+      icon = 'https://cdnjs.cloudflare.com/ajax/libs/octicons/8.5.0/svg/chevron-right.svg';
+    }
+    $header.append('<button type="button" class="btn btn-outline-dark mr-3 mb-2 float-left" onclick="collapseComponent(this)"><img src="' + icon + '" alt=""></button>');
   }
-  let $body = $('<div class="card-body"></div>').appendTo($el);
+  let $body = $('<div class="card-body"></div>');
+  if (!data._collapse) {
+    $el.append($body);
+  }
   if (!struct.fields) {
     let child = components.find(e => e.id === struct.value);
     return generateObject(data, child, false);
@@ -354,7 +362,7 @@ function generateObject(data, struct, header) {
     }
   }
   for (let field of Object.keys(data)) {
-    if (!validFields.includes(field)) {
+    if (!field.startsWith('_') && !validFields.includes(field)) {
       delete data[field];
     }
   }


### PR DESCRIPTION
![](https://i.imgur.com/RYk1MsB.png)

The collapse state is stored in a hidden field: `"_collapse": true`. The view was modified significantly so fields with underscores are hidden in the output. This has the added bonus that fields which are not compatible with the current filter are still stored in the `table` object, so switching back will keep the information.

This commit also removes the support to have a dot in the field id.

I'm planning to add a nicer header UI for collapsed components in the future.